### PR TITLE
Truncates top X maps to get under 50 length for regex

### DIFF
--- a/site/src/App.js
+++ b/site/src/App.js
@@ -273,7 +273,8 @@ function App() {
   const poeRegex = useMemo(() => {
     const re = '"' + [...new Set(filteredMaps.map(m => m.shorthand))].join('|') + '"'
     if (re.length > 50) {
-      return 'Too long, be more specific'
+      let splitMaps = re.substring(0,49).split('|')
+      return splitMaps.splice(0,splitMaps.length - 1).join('|') + '"'
     }
     return re
   }, [filteredMaps])
@@ -595,8 +596,8 @@ function App() {
                 <span className="tooltip-tag tooltip-tag-bottom tooltip-tag-notice">
                   <span className="tooltip-tag-text">
                     Generates string that can be copy/pasted to Path of Exile search boxes that will search for the
-                    filtered maps. PoE search fields are limited to 50 characters so the string is not generated until
-                    it can fit this criteria.
+                    filtered maps. PoE search fields are limited to 50 characters so the string is truncated to fit
+                    the top maps based off search criteria.
                   </span>
                   <label className="form-label">PoE regex</label>
                 </span>


### PR DESCRIPTION
I'm always frustrated when the app tells me to be more specific for a regex when I just want to highlight a variety of good maps to run for maven 10 ways or for leveling a new character with the few white to yellow maps I have

So now just truncates the regex to be under 50 characters rather than telling the user to be more specific.

https://github.com/deathbeam/maps-of-exile/assets/3909629/07c29727-f72d-4b0d-84f3-73cbb144cc70

