### PR TITLE
Automatically override currency card prices based on currency value

### DIFF
--- a/data/config.yaml
+++ b/data/config.yaml
@@ -32,6 +32,9 @@ data:
     - Primeval City
     - Labyrinth_Airlock
 
+  # Card price to currency override threshold
+  card-price-threshold: 100
+
   # Links
   poedb:
     base: https://poedb.tw/us/
@@ -41,8 +44,10 @@ data:
     base: https://www.poewiki.net/wiki/
     filepath: https://www.poewiki.net/wiki/Special:Redirect/file/
     api: https://www.poewiki.net/w/api.php
-  prices: https://poe.ninja/api/data/itemoverview?type=DivinationCard&league=
-  ninja: https://poe.ninja/challenge/divination-cards/
+  ninja:
+    cardbase: https://poe.ninja/challenge/divination-cards/
+    cardprices: https://poe.ninja/api/data/itemoverview?type=DivinationCard&league=
+    currencyprices: https://poe.ninja/api/data/currencyoverview?type=Currency&league=
 
   # Sheets
   metadata:

--- a/format.sh
+++ b/format.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-(cd data && black .)
+(cd data && black --line-length 120 .)
 (cd site && npm run fix)

--- a/site/src/App.jsx
+++ b/site/src/App.jsx
@@ -1,6 +1,6 @@
 import '@fortawesome/fontawesome-free/css/all.css'
 import 'bootstrap/dist/css/bootstrap.css'
-import { useAtomValue } from 'jotai'
+import { useAtom, useAtomValue } from 'jotai'
 
 import './App.css'
 import ScrollToTop from './components/ScrollToTop'
@@ -23,6 +23,8 @@ const Routes = () => {
 }
 
 function App() {
+  const [cardPricesAlert, setCardPricesAlert] = useAtom(state.alerts.cardPrices)
+
   return (
     <>
       <ScrollToTop />
@@ -35,6 +37,13 @@ function App() {
         <i className="fa-solid fa-fw fa-code-fork" />{' '}
         <span className="d-none d-md-inline">Data incorrect or missing? Open an issue</span>
       </a>
+      {cardPricesAlert && (
+        <div className="alert alert-primary position-fixed end-0 bottom-0 m-2 on-top" role="alert">
+          <b>New!</b> Currency cards under <b>100c</b> are now priced based on <b>poe.ninja</b> currency values to
+          improve accuracy.
+          <button type="button" className="btn-close" onClick={() => setCardPricesAlert(false)} />
+        </div>
+      )}
       <Routes />
     </>
   )

--- a/site/src/data/cards.json
+++ b/site/src/data/cards.json
@@ -80,7 +80,7 @@
         "price": 24.0,
         "reward": "Jewellery of Farrul, Item Level: 100, Shaper + Hunter Item",
         "stack": 3,
-        "standardPrice": 8.01,
+        "standardPrice": 7.51,
         "weight": 8
     },
     {
@@ -123,7 +123,7 @@
         "price": 20.0,
         "reward": "Megalomaniac, Corrupted",
         "stack": 3,
-        "standardPrice": 26.6,
+        "standardPrice": 28.5,
         "weight": 85
     },
     {
@@ -164,7 +164,7 @@
         "price": 3.0,
         "reward": "Asenath's Mark",
         "stack": 4,
-        "standardPrice": 8.0,
+        "standardPrice": 5.5,
         "weight": 256
     },
     {
@@ -182,10 +182,10 @@
         },
         "name": "A Sea of Blue",
         "ninja": "https://poe.ninja/challenge/divination-cards/a-sea-of-blue",
-        "price": 1.0,
+        "price": 0.3466666666666666,
         "reward": "13x Orb of Alteration",
         "stack": 3,
-        "standardPrice": 1.0,
+        "standardPrice": 0.38999999999999996,
         "weight": 7885
     },
     {
@@ -210,7 +210,7 @@
         "price": 20.0,
         "reward": "Jewel, Primordial, 1-2 Implicit, Corrupted",
         "stack": 5,
-        "standardPrice": 11.5,
+        "standardPrice": 12.0,
         "weight": 128
     },
     {
@@ -225,10 +225,10 @@
         },
         "name": "Abandoned Wealth",
         "ninja": "https://poe.ninja/challenge/divination-cards/abandoned-wealth",
-        "price": 25.0,
+        "price": 6.8999999999999995,
         "reward": "3x Exalted Orb",
         "stack": 5,
-        "standardPrice": 19.4,
+        "standardPrice": 21.15,
         "weight": 394
     },
     {
@@ -246,10 +246,10 @@
         },
         "name": "Acclimatisation",
         "ninja": "https://poe.ninja/challenge/divination-cards/acclimatisation",
-        "price": 1.0,
+        "price": 0.8,
         "reward": "20x Orb of Alteration",
         "stack": 2,
-        "standardPrice": 1.45,
+        "standardPrice": 0.8999999999999999,
         "weight": 3462
     },
     {
@@ -360,10 +360,10 @@
         },
         "name": "Alluring Bounty",
         "ninja": "https://poe.ninja/challenge/divination-cards/alluring-bounty",
-        "price": 14.0,
+        "price": 16.42857142857143,
         "reward": "10x Exalted Orb",
         "stack": 7,
-        "standardPrice": 22.5,
+        "standardPrice": 50.35714285714286,
         "weight": 183
     },
     {
@@ -397,7 +397,7 @@
         "price": 15.5,
         "reward": "Simulacrum",
         "stack": 3,
-        "standardPrice": 33.0,
+        "standardPrice": 34.4,
         "weight": 35
     },
     {
@@ -478,7 +478,7 @@
         "price": 69.0,
         "reward": "Voltaxic Rift, Corrupted",
         "stack": 13,
-        "standardPrice": 1.0,
+        "standardPrice": 1.5,
         "weight": 5
     },
     {
@@ -553,7 +553,7 @@
         "price": 5.0,
         "reward": "Shield, Shaper Item",
         "stack": 5,
-        "standardPrice": 3.0,
+        "standardPrice": 2.2,
         "weight": 632
     },
     {
@@ -571,7 +571,7 @@
         "price": 5.0,
         "reward": "Weapon, Corrupted",
         "stack": 4,
-        "standardPrice": 1.0,
+        "standardPrice": 1.1,
         "weight": 1218
     },
     {
@@ -589,7 +589,7 @@
         "price": 9.0,
         "reward": "Doryani's Fist, Corrupted",
         "stack": 5,
-        "standardPrice": 1.9,
+        "standardPrice": 1.6,
         "weight": 58
     },
     {
@@ -610,7 +610,7 @@
         "price": 191.71,
         "reward": "Experimented Item, Item Level: 100, Double-Influenced Item",
         "stack": 4,
-        "standardPrice": 13.5,
+        "standardPrice": 27.8,
         "weight": 216
     },
     {
@@ -649,7 +649,7 @@
         "price": 10.0,
         "reward": "Prismatic Jewel, Corrupted",
         "stack": 9,
-        "standardPrice": 5.0,
+        "standardPrice": 7.5,
         "weight": 342
     },
     {
@@ -670,7 +670,7 @@
         "price": 6.4,
         "reward": "Fishing Item",
         "stack": 8,
-        "standardPrice": 7.2,
+        "standardPrice": 5.0,
         "weight": 453
     },
     {
@@ -690,7 +690,7 @@
         "price": 20.0,
         "reward": "Atziri's Reflection",
         "stack": 5,
-        "standardPrice": 75.0,
+        "standardPrice": 64.86,
         "weight": 20
     },
     {
@@ -713,7 +713,7 @@
         "price": 42.0,
         "reward": "Cluster Jewel, Item Level: 84",
         "stack": 3,
-        "standardPrice": 23.5,
+        "standardPrice": 18.0,
         "weight": 198
     },
     {
@@ -734,7 +734,7 @@
         "price": 2.0,
         "reward": "Ring, Corrupted",
         "stack": 7,
-        "standardPrice": 1.9,
+        "standardPrice": 1.7,
         "weight": 2149
     },
     {
@@ -773,7 +773,7 @@
         "price": 4.0,
         "reward": "Bestiary Item",
         "stack": 6,
-        "standardPrice": 2.0,
+        "standardPrice": 2.1,
         "weight": 691
     },
     {
@@ -817,7 +817,7 @@
         "price": 10.0,
         "reward": "Six-Link Harbinger Bow, Item Level: 91",
         "stack": 6,
-        "standardPrice": 18.24,
+        "standardPrice": 9.4,
         "weight": 95
     },
     {
@@ -836,7 +836,7 @@
         "price": 150.0,
         "reward": "Diamond Ring, Item Level: 87, Two-Implicit, Synthesised",
         "stack": 2,
-        "standardPrice": 76.0,
+        "standardPrice": 55.5,
         "weight": 30
     },
     {
@@ -874,7 +874,7 @@
         "price": 498.86,
         "reward": "5x Divine Orb",
         "stack": 1,
-        "standardPrice": 1691.71,
+        "standardPrice": 1851.01,
         "weight": 50
     },
     {
@@ -894,7 +894,7 @@
         "price": 191.71,
         "reward": "5x Exalted Orb",
         "stack": 1,
-        "standardPrice": 130.87,
+        "standardPrice": 130.44,
         "weight": 50
     },
     {
@@ -915,7 +915,7 @@
         "price": 10.0,
         "reward": "One With Nothing, Corrupted",
         "stack": 5,
-        "standardPrice": 5.8,
+        "standardPrice": 5.6,
         "weight": 219
     },
     {
@@ -938,7 +938,7 @@
         "price": 6.0,
         "reward": "The Artist",
         "stack": 5,
-        "standardPrice": 1.0,
+        "standardPrice": 3.7,
         "weight": 622
     },
     {
@@ -961,7 +961,7 @@
         "price": 4.8,
         "reward": "Sulphite Scarab",
         "stack": 3,
-        "standardPrice": 1.3,
+        "standardPrice": 1.8,
         "weight": 1130
     },
     {
@@ -980,7 +980,7 @@
         "price": 10.0,
         "reward": "Xoph's Blood, Corrupted",
         "stack": 6,
-        "standardPrice": 10.5,
+        "standardPrice": 7.6,
         "weight": 6
     },
     {
@@ -1021,7 +1021,7 @@
         "price": 2.2,
         "reward": "Scarab",
         "stack": 2,
-        "standardPrice": 3.8,
+        "standardPrice": 2.1,
         "weight": 753
     },
     {
@@ -1058,7 +1058,7 @@
         "price": 4.0,
         "reward": "5x Chaos Orb",
         "stack": 1,
-        "standardPrice": 1.9,
+        "standardPrice": 2.9,
         "weight": 3788
     },
     {
@@ -1096,7 +1096,7 @@
         "price": 5.5,
         "reward": "76x Simulacrum Splinter",
         "stack": 8,
-        "standardPrice": 2.2,
+        "standardPrice": 2.8,
         "weight": 276
     },
     {
@@ -1114,7 +1114,7 @@
         "price": 1917.1,
         "reward": "Stranglegasp",
         "stack": 6,
-        "standardPrice": 2218.64,
+        "standardPrice": 1560.14,
         "weight": 8
     },
     {
@@ -1151,7 +1151,7 @@
         "price": 5.0,
         "reward": "Farrul Item",
         "stack": 4,
-        "standardPrice": 8.0,
+        "standardPrice": 6.0,
         "weight": 230
     },
     {
@@ -1169,10 +1169,10 @@
         },
         "name": "Coveted Possession",
         "ninja": "https://poe.ninja/challenge/divination-cards/coveted-possession",
-        "price": 1.3,
+        "price": 0.43888888888888894,
         "reward": "5x Regal Orb",
         "stack": 9,
-        "standardPrice": 1.0,
+        "standardPrice": 0.3388888888888889,
         "weight": 2873
     },
     {
@@ -1210,7 +1210,7 @@
         "price": 7.0,
         "reward": "Bone Helmet, Elder Item",
         "stack": 4,
-        "standardPrice": 11.8,
+        "standardPrice": 8.8,
         "weight": 71
     },
     {
@@ -1239,10 +1239,10 @@
         },
         "name": "Darker Half",
         "ninja": "https://poe.ninja/challenge/divination-cards/darker-half",
-        "price": 10.0,
+        "price": 34.733333333333334,
         "reward": "5x Eldritch Chaos Orb",
         "stack": 3,
-        "standardPrice": 70.0,
+        "standardPrice": 90.38333333333333,
         "weight": 30
     },
     {
@@ -1260,7 +1260,7 @@
         "price": 20.0,
         "reward": "Torrent's Reclamation, Two-Implicit, Corrupted",
         "stack": 6,
-        "standardPrice": 23.0,
+        "standardPrice": 31.0,
         "weight": 24
     },
     {
@@ -1280,7 +1280,7 @@
         "price": 2.0,
         "reward": "Mon'tregul's Grasp",
         "stack": 4,
-        "standardPrice": 1.1,
+        "standardPrice": 1.0,
         "weight": 1197
     },
     {
@@ -1320,7 +1320,7 @@
         "price": 14.0,
         "reward": "10x Delirium Orb",
         "stack": 11,
-        "standardPrice": 1.8,
+        "standardPrice": 5.0,
         "weight": 60
     },
     {
@@ -1335,10 +1335,10 @@
         },
         "name": "Demigod's Wager",
         "ninja": "https://poe.ninja/challenge/divination-cards/demigods-wager",
-        "price": 5.0,
+        "price": 1.8685714285714285,
         "reward": "Orb of Annulment",
         "stack": 7,
-        "standardPrice": 1.9,
+        "standardPrice": 2.497142857142857,
         "weight": 642
     },
     {
@@ -1356,7 +1356,7 @@
         "price": 525.29,
         "reward": "Level 6 Awakened Support Gem, Quality: +23%, Corrupted",
         "stack": 9,
-        "standardPrice": 277.33,
+        "standardPrice": 264.43,
         "weight": 26
     },
     {
@@ -1375,7 +1375,7 @@
         "price": 4.0,
         "reward": "Prism Guardian",
         "stack": 3,
-        "standardPrice": 20.0,
+        "standardPrice": 19.0,
         "weight": 160
     },
     {
@@ -1418,7 +1418,7 @@
         "price": 10.0,
         "reward": "Support Gem, Quality: +23%, Corrupted",
         "stack": 7,
-        "standardPrice": 2.13,
+        "standardPrice": 2.27,
         "weight": 1106
     },
     {
@@ -1436,7 +1436,7 @@
         "price": 2.0,
         "reward": "Delirium Orb",
         "stack": 5,
-        "standardPrice": 2.3,
+        "standardPrice": 2.0,
         "weight": 383
     },
     {
@@ -1455,10 +1455,10 @@
         },
         "name": "Divine Beauty",
         "ninja": "https://poe.ninja/challenge/divination-cards/divine-beauty",
-        "price": 70.0,
+        "price": 111.66166666666666,
         "reward": "7x Divine Orb",
         "stack": 12,
-        "standardPrice": 100.0,
+        "standardPrice": 154.26250000000002,
         "weight": 408
     },
     {
@@ -1473,7 +1473,7 @@
         "ninja": "https://poe.ninja/challenge/divination-cards/divine-justice",
         "reward": "Grand Spectrum, Corrupted",
         "stack": 1,
-        "standardPrice": 8.8,
+        "standardPrice": 7.0,
         "weight": 355
     },
     {
@@ -1517,7 +1517,7 @@
         "ninja": "https://poe.ninja/challenge/divination-cards/doryanis-epiphany",
         "reward": "Level 21 Transfigured Gem, Quality: +20%, Corrupted",
         "stack": 3,
-        "standardPrice": 142.44,
+        "standardPrice": 69.0,
         "weight": 90
     },
     {
@@ -1533,7 +1533,7 @@
         "price": 9.0,
         "reward": "Six-Link Astral Plate, Item Level: 100, Influenced Item",
         "stack": 5,
-        "standardPrice": 20.0,
+        "standardPrice": 22.8,
         "weight": 34
     },
     {
@@ -1575,7 +1575,7 @@
         "price": 100.0,
         "reward": "Body Armour, Item Level: 100, Double-Influenced Item",
         "stack": 2,
-        "standardPrice": 130.0,
+        "standardPrice": 50.0,
         "weight": 13
     },
     {
@@ -1597,7 +1597,7 @@
         "ninja": "https://poe.ninja/challenge/divination-cards/dying-anguish",
         "reward": "Level 19 Transfigured Gem, Quality: +19%",
         "stack": 8,
-        "standardPrice": 3.6,
+        "standardPrice": 3.8,
         "weight": 1412
     },
     {
@@ -1616,7 +1616,7 @@
         "price": 15.0,
         "reward": "Diamond Ring, Item Level: 100, Shaper + Elder Item",
         "stack": 10,
-        "standardPrice": 15.0,
+        "standardPrice": 14.1,
         "weight": 33
     },
     {
@@ -1662,7 +1662,7 @@
         "price": 35.0,
         "reward": "Fidelitas' Spike,  Two-Implicit,  Corrupted",
         "stack": 3,
-        "standardPrice": 1.1,
+        "standardPrice": 1.6,
         "weight": 442
     },
     {
@@ -1696,7 +1696,7 @@
         "price": 3.0,
         "reward": "Item, Item Level: 100, Perfect Eldritch Implicit Modifier",
         "stack": 4,
-        "standardPrice": 7.0
+        "standardPrice": 9.1
     },
     {
         "art": "EmperorOfPurity",
@@ -1716,7 +1716,7 @@
         "price": 5.0,
         "reward": "Six-Link Holy Chainmail, Item Level: 60",
         "stack": 7,
-        "standardPrice": 1.0,
+        "standardPrice": 1.9,
         "weight": 1608
     },
     {
@@ -1755,7 +1755,7 @@
         "price": 4.8,
         "reward": "Maloney's Mechanism",
         "stack": 7,
-        "standardPrice": 5.0,
+        "standardPrice": 2.6,
         "weight": 430
     },
     {
@@ -1773,7 +1773,7 @@
         "price": 19.5,
         "reward": "Rigwald's Quills, Two-Implicit, Corrupted",
         "stack": 9,
-        "standardPrice": 38.8,
+        "standardPrice": 29.4,
         "weight": 46
     },
     {
@@ -1789,7 +1789,7 @@
         "price": 60.0,
         "reward": "Replica Cortex",
         "stack": 4,
-        "standardPrice": 113.2,
+        "standardPrice": 92.5,
         "weight": 26
     },
     {
@@ -1802,10 +1802,10 @@
         },
         "name": "Ever-Changing",
         "ninja": "https://poe.ninja/challenge/divination-cards/ever-changing",
-        "price": 1.9,
+        "price": 1.6666666666666667,
         "reward": "10x Orb of Unmaking",
         "stack": 3,
-        "standardPrice": 1.0,
+        "standardPrice": 4.8,
         "weight": 1353
     },
     {
@@ -1823,7 +1823,7 @@
         "price": 23.7,
         "reward": "League-Specific Item, Double-Influenced Item, Item Level: 97, Two-Implicit, Corrupted",
         "stack": 9,
-        "standardPrice": 29.02,
+        "standardPrice": 35.13,
         "weight": 13
     },
     {
@@ -1842,7 +1842,7 @@
         "price": 766.84,
         "reward": "Nimis",
         "stack": 7,
-        "standardPrice": 1386.65
+        "standardPrice": 1137.05
     },
     {
         "art": "ForbiddenPower",
@@ -1888,7 +1888,7 @@
         "price": 13.6,
         "reward": "Ngamahu's Flame, Two-Implicit, Corrupted",
         "stack": 8,
-        "standardPrice": 27.33,
+        "standardPrice": 10.0,
         "weight": 187
     },
     {
@@ -1908,7 +1908,7 @@
         "price": 30.0,
         "reward": "Helmet, Double-Influenced Item, Item Level: 100",
         "stack": 4,
-        "standardPrice": 43.0,
+        "standardPrice": 44.0,
         "weight": 27
     },
     {
@@ -2053,7 +2053,7 @@
         "price": 4.0,
         "reward": "Shaper Guardian Map",
         "stack": 4,
-        "standardPrice": 2.0,
+        "standardPrice": 3.0,
         "weight": 1396
     },
     {
@@ -2092,7 +2092,7 @@
         "price": 5.0,
         "reward": "Metamorph Item",
         "stack": 4,
-        "standardPrice": 3.4,
+        "standardPrice": 3.0,
         "weight": 298
     },
     {
@@ -2279,7 +2279,7 @@
         "price": 2.0,
         "reward": "Two-Stone Ring",
         "stack": 2,
-        "standardPrice": 2.7,
+        "standardPrice": 3.0,
         "weight": 1770
     },
     {
@@ -2308,7 +2308,7 @@
         "price": 60.0,
         "reward": "Exceptional Gem, Quality: +1-20%",
         "stack": 3,
-        "standardPrice": 28.3,
+        "standardPrice": 28.0,
         "weight": 90
     },
     {
@@ -2490,7 +2490,7 @@
         "price": 36424.9,
         "reward": "Mirror of Kalandra",
         "stack": 9,
-        "standardPrice": 36052.9,
+        "standardPrice": 45878.6,
         "weight": 5
     },
     {
@@ -2568,7 +2568,7 @@
         "price": 5.0,
         "reward": "The Taming",
         "stack": 3,
-        "standardPrice": 7.0,
+        "standardPrice": 5.8,
         "weight": 239
     },
     {
@@ -2598,7 +2598,7 @@
         "price": 3834.2,
         "reward": "2x Fracturing Orb",
         "stack": 2,
-        "standardPrice": 4270.88
+        "standardPrice": 4234.68
     },
     {
         "art": "ImmortalResolve",
@@ -2636,7 +2636,7 @@
         "price": 191.71,
         "reward": "Jewellery, Item Level: 100, Three-Implicit, Synthesised",
         "stack": 5,
-        "standardPrice": 277.33,
+        "standardPrice": 264.43,
         "weight": 22
     },
     {
@@ -2710,7 +2710,7 @@
         "price": 7.0,
         "reward": "Forbidden Shako",
         "stack": 9,
-        "standardPrice": 60.0,
+        "standardPrice": 18.5,
         "weight": 117
     },
     {
@@ -2731,7 +2731,7 @@
         "price": 8.0,
         "reward": "Synthesis Map",
         "stack": 5,
-        "standardPrice": 4.6,
+        "standardPrice": 5.0,
         "weight": 447
     },
     {
@@ -2750,7 +2750,7 @@
         "price": 9.7,
         "reward": "Eldritch Bone Helmet (Concentrated Effect), Item Level: 89, Elder Item",
         "stack": 7,
-        "standardPrice": 23.4,
+        "standardPrice": 22.1,
         "weight": 5
     },
     {
@@ -2812,7 +2812,7 @@
         "price": 0.99,
         "reward": "Two-Stone Ring",
         "stack": 7,
-        "standardPrice": 0.5,
+        "standardPrice": 0.51,
         "weight": 17863
     },
     {
@@ -2865,7 +2865,7 @@
         "price": 9.1,
         "reward": "Nebulis",
         "stack": 6,
-        "standardPrice": 16.7,
+        "standardPrice": 10.0,
         "weight": 99
     },
     {
@@ -3087,7 +3087,7 @@
         "price": 191.71,
         "reward": "Unnatural Instinct, Two-Implicit, Corrupted",
         "stack": 4,
-        "standardPrice": 500.33,
+        "standardPrice": 351.16,
         "weight": 5
     },
     {
@@ -3106,10 +3106,10 @@
         },
         "name": "Loyalty",
         "ninja": "https://poe.ninja/challenge/divination-cards/loyalty",
-        "price": 1.0,
+        "price": 0.10200000000000001,
         "reward": "3x Orb of Fusing",
         "stack": 5,
-        "standardPrice": 1.0,
+        "standardPrice": 0.198,
         "weight": 34787
     },
     {
@@ -3129,10 +3129,10 @@
         },
         "name": "Lucky Connections",
         "ninja": "https://poe.ninja/challenge/divination-cards/lucky-connections",
-        "price": 1.0,
+        "price": 0.48571428571428577,
         "reward": "20x Orb of Fusing",
         "stack": 7,
-        "standardPrice": 1.0,
+        "standardPrice": 0.942857142857143,
         "weight": 7780
     },
     {
@@ -3293,10 +3293,10 @@
         },
         "name": "Lucky Deck",
         "ninja": "https://poe.ninja/challenge/divination-cards/lucky-deck",
-        "price": 2.4,
+        "price": 3.3333333333333335,
         "reward": "10x Stacked Deck",
         "stack": 9,
-        "standardPrice": 4.44,
+        "standardPrice": 3.2,
         "weight": 201
     },
     {
@@ -3314,7 +3314,7 @@
         "price": 958.55,
         "reward": "Voices, Corrupted",
         "stack": 7,
-        "standardPrice": 218.93,
+        "standardPrice": 222.22,
         "weight": 67
     },
     {
@@ -3355,7 +3355,7 @@
         "price": 96.17,
         "reward": "Item, Item Level: 100, Three-Implicit, Synthesised",
         "stack": 5,
-        "standardPrice": 86.0,
+        "standardPrice": 91.0,
         "weight": 51
     },
     {
@@ -3392,7 +3392,7 @@
         "price": 276.06,
         "reward": " Onyx Amulet, Item Level: 85, Quality: +20%, Influenced Item, Four Anointments, Incubating Talisman Item, Corrupted",
         "stack": 8,
-        "standardPrice": 388.66,
+        "standardPrice": 264.43,
         "weight": 1
     },
     {
@@ -3412,7 +3412,7 @@
         "price": 5.0,
         "reward": "Eyes of the Greatwolf",
         "stack": 16,
-        "standardPrice": 14.0,
+        "standardPrice": 15.0,
         "weight": 212
     },
     {
@@ -3433,7 +3433,7 @@
         "price": 5.0,
         "reward": "Merciless Two-Hand Weapon, Item Level: 100",
         "stack": 4,
-        "standardPrice": 1.0,
+        "standardPrice": 8.2,
         "weight": 251
     },
     {
@@ -3475,7 +3475,7 @@
         "price": 20.0,
         "reward": "Shroud of the Lightless",
         "stack": 6,
-        "standardPrice": 47.0,
+        "standardPrice": 38.0,
         "weight": 117
     },
     {
@@ -3522,10 +3522,10 @@
         },
         "name": "No Traces",
         "ninja": "https://poe.ninja/challenge/divination-cards/no-traces",
-        "price": 1.0,
+        "price": 1.7666666666666668,
         "reward": "30x Orb of Scouring",
         "stack": 9,
-        "standardPrice": 1.0,
+        "standardPrice": 2.033333333333333,
         "weight": 2803
     },
     {
@@ -3543,7 +3543,7 @@
         "price": 30.0,
         "reward": "Bone Helmet, Item Level: 100, Elder Item",
         "stack": 4,
-        "standardPrice": 12.7,
+        "standardPrice": 40.0,
         "weight": 17
     },
     {
@@ -3563,7 +3563,7 @@
         "price": 5.0,
         "reward": "10x Incubator, Item Level: 84",
         "stack": 8,
-        "standardPrice": 4.1,
+        "standardPrice": 3.9,
         "weight": 600
     },
     {
@@ -3584,7 +3584,7 @@
         "price": 29.0,
         "reward": "Timeless Jewel",
         "stack": 5,
-        "standardPrice": 4.5,
+        "standardPrice": 6.0,
         "weight": 235
     },
     {
@@ -3605,7 +3605,7 @@
         "price": 4.0,
         "reward": "Jewellery, Item Level: 100, Shaper Item",
         "stack": 5,
-        "standardPrice": 4.2,
+        "standardPrice": 5.0,
         "weight": 38
     },
     {
@@ -3680,7 +3680,7 @@
         "price": 8.0,
         "reward": "Farrul's Fur",
         "stack": 7,
-        "standardPrice": 23.4,
+        "standardPrice": 22.6,
         "weight": 48
     },
     {
@@ -3734,7 +3734,7 @@
         "price": 1.0,
         "reward": "Perandus' Gold Ring",
         "stack": 10,
-        "standardPrice": 0.66,
+        "standardPrice": 0.96,
         "weight": 11903
     },
     {
@@ -3840,7 +3840,7 @@
         "price": 9.3,
         "reward": "Charan's Sword",
         "stack": 27,
-        "standardPrice": 3.2,
+        "standardPrice": 2.8,
         "weight": 83
     },
     {
@@ -3874,7 +3874,7 @@
         "price": 75.0,
         "reward": "Precursor's Emblem, Corrupted",
         "stack": 8,
-        "standardPrice": 40.0,
+        "standardPrice": 35.0,
         "weight": 44
     },
     {
@@ -3908,7 +3908,7 @@
         "price": 5.0,
         "reward": "Armour, Quality: +30%",
         "stack": 3,
-        "standardPrice": 2.0,
+        "standardPrice": 2.3,
         "weight": 927
     },
     {
@@ -3949,7 +3949,7 @@
         "price": 862.7,
         "reward": "Mirror Shard",
         "stack": 13,
-        "standardPrice": 1018.73,
+        "standardPrice": 972.22,
         "weight": 82
     },
     {
@@ -3988,7 +3988,7 @@
         "price": 14.8,
         "reward": "The Pandemonius",
         "stack": 7,
-        "standardPrice": 9.6,
+        "standardPrice": 10.8,
         "weight": 55
     },
     {
@@ -4001,10 +4001,10 @@
         },
         "name": "Society's Remorse",
         "ninja": "https://poe.ninja/challenge/divination-cards/societys-remorse",
-        "price": 1.0,
+        "price": 0.8,
         "reward": "10x Orb of Alteration",
         "stack": 1,
-        "standardPrice": 1.0,
+        "standardPrice": 0.8999999999999999,
         "weight": 3496
     },
     {
@@ -4026,7 +4026,7 @@
         "price": 13.8,
         "reward": "Blueprint, Area Level: 83, Fully Revealed",
         "stack": 5,
-        "standardPrice": 27.77,
+        "standardPrice": 20.0,
         "weight": 587
     },
     {
@@ -4047,7 +4047,7 @@
         "price": 20.0,
         "reward": " Experimented Two-Handed Weapon, Item Level: 86, Quality: +30%",
         "stack": 5,
-        "standardPrice": 15.0,
+        "standardPrice": 9.9,
         "weight": 1094
     },
     {
@@ -4077,7 +4077,7 @@
         "price": 1.0,
         "reward": "Electrocuting Jewellery, Item Level: 76",
         "stack": 3,
-        "standardPrice": 0.44,
+        "standardPrice": 0.5,
         "weight": 7772
     },
     {
@@ -4095,7 +4095,7 @@
         "price": 38.6,
         "reward": "Bottled Faith",
         "stack": 6,
-        "standardPrice": 37.2,
+        "standardPrice": 37.0,
         "weight": 27
     },
     {
@@ -4121,7 +4121,7 @@
         "ninja": "https://poe.ninja/challenge/divination-cards/terrible-secret-of-space",
         "reward": "Level 21 Transfigured Golem Gem, Quality: +23%, Corrupted",
         "stack": 8,
-        "standardPrice": 4.4,
+        "standardPrice": 3.3,
         "weight": 209
     },
     {
@@ -4141,7 +4141,7 @@
         "price": 13.2,
         "reward": "Inspired Learning",
         "stack": 8,
-        "standardPrice": 5.9,
+        "standardPrice": 4.8,
         "weight": 146
     },
     {
@@ -4182,7 +4182,7 @@
         "price": 1.0,
         "reward": "Victario's Influence",
         "stack": 6,
-        "standardPrice": 1.0,
+        "standardPrice": 0.83,
         "weight": 9511
     },
     {
@@ -4227,7 +4227,7 @@
         "price": 5597.93,
         "reward": "Mageblood",
         "stack": 5,
-        "standardPrice": 9429.22,
+        "standardPrice": 9255.05,
         "weight": 6
     },
     {
@@ -4277,7 +4277,7 @@
         "price": 1.0,
         "reward": "Map, Map Tier: 12",
         "stack": 10,
-        "standardPrice": 0.6,
+        "standardPrice": 1.0,
         "weight": 12373
     },
     {
@@ -4317,7 +4317,7 @@
         "price": 70.0,
         "reward": "Level 4 Enhance, Corrupted",
         "stack": 11,
-        "standardPrice": 29.1,
+        "standardPrice": 28.1,
         "weight": 25
     },
     {
@@ -4335,7 +4335,7 @@
         "price": 20.0,
         "reward": "Item, Elevated Item, Influenced Item",
         "stack": 5,
-        "standardPrice": 56.0,
+        "standardPrice": 60.0,
         "weight": 12
     },
     {
@@ -4353,7 +4353,7 @@
         "price": 17.0,
         "reward": "The Eternity Shroud, Two-Implicit, Corrupted",
         "stack": 7,
-        "standardPrice": 76.0,
+        "standardPrice": 88.0,
         "weight": 2
     },
     {
@@ -4375,7 +4375,7 @@
         "price": 9.0,
         "reward": "Mj\u00f6lner, Corrupted",
         "stack": 12,
-        "standardPrice": 3.0,
+        "standardPrice": 2.8,
         "weight": 237
     },
     {
@@ -4441,7 +4441,7 @@
         "price": 4.0,
         "reward": "Fecund Ursine Pelt, Warlord Item",
         "stack": 6,
-        "standardPrice": 1.6,
+        "standardPrice": 2.0,
         "weight": 780
     },
     {
@@ -4485,7 +4485,7 @@
         "price": 1.0,
         "reward": "Maligaro's Virtuosity",
         "stack": 9,
-        "standardPrice": 3.3,
+        "standardPrice": 2.65,
         "weight": 2740
     },
     {
@@ -4535,7 +4535,7 @@
         "price": 1.0,
         "reward": "Chin Sol",
         "stack": 6,
-        "standardPrice": 0.5,
+        "standardPrice": 0.8,
         "weight": 11929
     },
     {
@@ -4550,7 +4550,7 @@
         "ninja": "https://poe.ninja/challenge/divination-cards/the-blessing-of-moosh",
         "reward": "Level 21 Transfigured Gem, Corrupted",
         "stack": 4,
-        "standardPrice": 6.5,
+        "standardPrice": 8.0,
         "weight": 2541
     },
     {
@@ -4607,7 +4607,7 @@
         "price": 5.3,
         "reward": "Merciless Tornado Wand, Item Level: 100",
         "stack": 5,
-        "standardPrice": 10.6,
+        "standardPrice": 5.0,
         "weight": 164
     },
     {
@@ -4625,7 +4625,7 @@
         "price": 10.0,
         "reward": "Breach Item",
         "stack": 4,
-        "standardPrice": 2.4,
+        "standardPrice": 3.0,
         "weight": 221
     },
     {
@@ -4644,7 +4644,7 @@
         "price": 5.0,
         "reward": "Voll's Devotion, Corrupted",
         "stack": 8,
-        "standardPrice": 4.2,
+        "standardPrice": 3.6,
         "weight": 113
     },
     {
@@ -4691,7 +4691,7 @@
         "price": 2.7,
         "reward": "3x Deafening Essence",
         "stack": 8,
-        "standardPrice": 0.43,
+        "standardPrice": 1.0,
         "weight": 216
     },
     {
@@ -4750,7 +4750,7 @@
         "price": 3.0,
         "reward": "Divination Scarab",
         "stack": 4,
-        "standardPrice": 1.0,
+        "standardPrice": 1.2,
         "weight": 1408
     },
     {
@@ -4775,7 +4775,7 @@
         "price": 1.0,
         "reward": "Life Armour",
         "stack": 4,
-        "standardPrice": 0.5,
+        "standardPrice": 1.0,
         "weight": 24909
     },
     {
@@ -4791,7 +4791,7 @@
         "price": 3.0,
         "reward": "10x Cartographer's Chisel",
         "stack": 1,
-        "standardPrice": 1.66,
+        "standardPrice": 1.91,
         "weight": 7166
     },
     {
@@ -4888,10 +4888,10 @@
         },
         "name": "The Catalyst",
         "ninja": "https://poe.ninja/challenge/divination-cards/the-catalyst",
-        "price": 1.0,
+        "price": 0.31666666666666665,
         "reward": "Vaal Orb",
         "stack": 3,
-        "standardPrice": 1.0,
+        "standardPrice": 0.4066666666666666,
         "weight": 25989
     },
     {
@@ -4919,7 +4919,7 @@
         "price": 39.5,
         "reward": "Fishing Rod, Incubated, Item Level: 99",
         "stack": 18,
-        "standardPrice": 39.1,
+        "standardPrice": 31.5,
         "weight": 17
     },
     {
@@ -4940,7 +4940,7 @@
         "price": 6.2,
         "reward": "Six-Link Astral Plate",
         "stack": 6,
-        "standardPrice": 6.8,
+        "standardPrice": 5.0,
         "weight": 858
     },
     {
@@ -4956,7 +4956,7 @@
         "price": 8.8,
         "reward": "Opal Ring, Item Level: 100, Shaper Item",
         "stack": 10,
-        "standardPrice": 8.6,
+        "standardPrice": 7.4,
         "weight": 32
     },
     {
@@ -4998,7 +4998,7 @@
         "price": 1341.97,
         "reward": "Level 6 Awakened Support Gem, Quality: +20%, Corrupted",
         "stack": 3,
-        "standardPrice": 554.66,
+        "standardPrice": 528.86,
         "weight": 7
     },
     {
@@ -5014,7 +5014,7 @@
         "price": 34.2,
         "reward": "Skin of the Lords, Corrupted",
         "stack": 5,
-        "standardPrice": 4.4,
+        "standardPrice": 2.6,
         "weight": 5
     },
     {
@@ -5041,7 +5041,7 @@
         "price": 2.0,
         "reward": "Lightning Coil",
         "stack": 8,
-        "standardPrice": 0.9,
+        "standardPrice": 1.0,
         "weight": 2367
     },
     {
@@ -5062,7 +5062,7 @@
         "price": 5.3,
         "reward": "Doryani's Fist",
         "stack": 9,
-        "standardPrice": 1.9,
+        "standardPrice": 2.0,
         "weight": 498
     },
     {
@@ -5125,7 +5125,7 @@
         "price": 30.1,
         "reward": "Soul Ripper",
         "stack": 6,
-        "standardPrice": 90.73,
+        "standardPrice": 80.81,
         "weight": 21
     },
     {
@@ -5145,7 +5145,7 @@
         "price": 7.0,
         "reward": "Six-Link Body Armour, Item Level: 100",
         "stack": 6,
-        "standardPrice": 1.7,
+        "standardPrice": 2.0,
         "weight": 2227
     },
     {
@@ -5166,7 +5166,7 @@
         "price": 5.0,
         "reward": "Six-Link Staff, Item Level: 55",
         "stack": 6,
-        "standardPrice": 1.0,
+        "standardPrice": 2.0,
         "weight": 1002
     },
     {
@@ -5184,7 +5184,7 @@
         "price": 4.9,
         "reward": "Severed in Sleep, Corrupted",
         "stack": 6,
-        "standardPrice": 1.0,
+        "standardPrice": 1.4,
         "weight": 293
     },
     {
@@ -5202,7 +5202,7 @@
         "price": 5.0,
         "reward": "Cartography Scarab",
         "stack": 5,
-        "standardPrice": 1.8,
+        "standardPrice": 2.0,
         "weight": 1021
     },
     {
@@ -5245,7 +5245,7 @@
         "price": 5.0,
         "reward": "Tidebreaker",
         "stack": 5,
-        "standardPrice": 2.7,
+        "standardPrice": 3.0,
         "weight": 160
     },
     {
@@ -5265,7 +5265,7 @@
         "price": 1840.42,
         "reward": "Headhunter, Two-Implicit, Corrupted",
         "stack": 10,
-        "standardPrice": 357.76,
+        "standardPrice": 802.87,
         "weight": 2
     },
     {
@@ -5308,7 +5308,7 @@
         "price": 107.2,
         "reward": "Watcher's Eye, Two-Implicit, Corrupted",
         "stack": 9,
-        "standardPrice": 35.9,
+        "standardPrice": 45.3,
         "weight": 13
     },
     {
@@ -5331,7 +5331,7 @@
         "price": 766.84,
         "reward": "Headhunter",
         "stack": 8,
-        "standardPrice": 831.99,
+        "standardPrice": 793.29,
         "weight": 15
     },
     {
@@ -5540,7 +5540,7 @@
         "price": 39.35,
         "reward": "Level 4 Empower, Corrupted",
         "stack": 11,
-        "standardPrice": 19.1,
+        "standardPrice": 20.0,
         "weight": 19
     },
     {
@@ -5559,7 +5559,7 @@
         "price": 20.0,
         "reward": "Chayula Item",
         "stack": 6,
-        "standardPrice": 10.0,
+        "standardPrice": 9.3,
         "weight": 104
     },
     {
@@ -5619,7 +5619,7 @@
         "price": 20.0,
         "reward": "Belt, Double-Influenced Item",
         "stack": 7,
-        "standardPrice": 9.7,
+        "standardPrice": 10.0,
         "weight": 298
     },
     {
@@ -5661,7 +5661,7 @@
         "price": 19.0,
         "reward": "Uber Elder Fragment",
         "stack": 4,
-        "standardPrice": 8.5,
+        "standardPrice": 10.0,
         "weight": 459
     },
     {
@@ -5677,7 +5677,7 @@
         "price": 100.0,
         "reward": "Vaal Breach, Quality: +6%, Corrupted",
         "stack": 6,
-        "standardPrice": 5.8,
+        "standardPrice": 14.0,
         "weight": 32
     },
     {
@@ -5864,7 +5864,7 @@
         "price": 766.84,
         "reward": "Voidforge",
         "stack": 9,
-        "standardPrice": 3.69,
+        "standardPrice": 4.0,
         "weight": 8
     },
     {
@@ -5908,7 +5908,7 @@
         "price": 30.0,
         "reward": "Spiked Gloves of the Conquest (Culling Strike), Item Level: 86, Warlord Item",
         "stack": 4,
-        "standardPrice": 104.0,
+        "standardPrice": 76.5,
         "weight": 21
     },
     {
@@ -5954,7 +5954,7 @@
         "price": 20.0,
         "reward": "Victario's Influence, Two-Implicit, Corrupted",
         "stack": 3,
-        "standardPrice": 9.0,
+        "standardPrice": 9.7,
         "weight": 345
     },
     {
@@ -5976,7 +5976,7 @@
         "price": 3.0,
         "reward": "Seven-League Step",
         "stack": 5,
-        "standardPrice": 3.8,
+        "standardPrice": 3.5,
         "weight": 565
     },
     {
@@ -5997,7 +5997,7 @@
         "price": 42.0,
         "reward": "Timeless Jewel, Two-Implicit, Corrupted",
         "stack": 4,
-        "standardPrice": 50.0,
+        "standardPrice": 35.09,
         "weight": 11
     },
     {
@@ -6016,7 +6016,7 @@
         "price": 5.5,
         "reward": "Six-Link Vaal Regalia",
         "stack": 7,
-        "standardPrice": 2.0,
+        "standardPrice": 2.4,
         "weight": 546
     },
     {
@@ -6052,7 +6052,7 @@
         "price": 79.0,
         "reward": "Chayula's Flawless Breachstone",
         "stack": 8,
-        "standardPrice": 20.6,
+        "standardPrice": 16.2,
         "weight": 8
     },
     {
@@ -6072,7 +6072,7 @@
         "price": 5.0,
         "reward": "Jewel, Corrupted",
         "stack": 10,
-        "standardPrice": 1.0,
+        "standardPrice": 1.7,
         "weight": 57
     },
     {
@@ -6136,7 +6136,7 @@
         "price": 383.42,
         "reward": "Headhunter, Corrupted",
         "stack": 11,
-        "standardPrice": 154.11,
+        "standardPrice": 186.19,
         "weight": 5
     },
     {
@@ -6151,10 +6151,10 @@
         },
         "name": "The Finishing Touch",
         "ninja": "https://poe.ninja/challenge/divination-cards/the-finishing-touch",
-        "price": 3.0,
+        "price": 12.5,
         "reward": "1x Fertile Catalyst",
         "stack": 2,
-        "standardPrice": 3.0,
+        "standardPrice": 3.45,
         "weight": 498
     },
     {
@@ -6173,7 +6173,7 @@
         "price": 35.0,
         "reward": "Albino Rhoa Feather",
         "stack": 4,
-        "standardPrice": 53.0,
+        "standardPrice": 54.0,
         "weight": 14
     },
     {
@@ -6224,7 +6224,7 @@
         "price": 1.0,
         "reward": "Five-Link Staff, Item Level: 66",
         "stack": 5,
-        "standardPrice": 0.96,
+        "standardPrice": 1.0,
         "weight": 29893
     },
     {
@@ -6237,10 +6237,10 @@
         },
         "name": "The Fool",
         "ninja": "https://poe.ninja/challenge/divination-cards/the-fool",
-        "price": 1.0,
+        "price": 0.4,
         "reward": "20x Orb of Chance",
         "stack": 4,
-        "standardPrice": 1.0,
+        "standardPrice": 0.65,
         "weight": 3439
     },
     {
@@ -6258,7 +6258,7 @@
         "price": 28.2,
         "reward": "Leather Belt, Double-Influenced Item",
         "stack": 6,
-        "standardPrice": 11.4,
+        "standardPrice": 11.0,
         "weight": 369
     },
     {
@@ -6279,7 +6279,7 @@
         "price": 5.0,
         "reward": "Varunastra",
         "stack": 7,
-        "standardPrice": 2.0,
+        "standardPrice": 5.0,
         "weight": 495
     },
     {
@@ -6340,10 +6340,10 @@
         },
         "name": "The Fortunate",
         "ninja": "https://poe.ninja/challenge/divination-cards/the-fortunate",
-        "price": 20.0,
+        "price": 31.90333333333333,
         "reward": "2x Divine Orb",
         "stack": 12,
-        "standardPrice": 30.0,
+        "standardPrice": 44.074999999999996,
         "weight": 1226
     },
     {
@@ -6361,7 +6361,7 @@
         "price": 4.7,
         "reward": "Replica Item",
         "stack": 6,
-        "standardPrice": 9.4,
+        "standardPrice": 8.2,
         "weight": 1154
     },
     {
@@ -6403,7 +6403,7 @@
         "price": 14.0,
         "reward": "Bramblejack, Two-Implicit, Corrupted",
         "stack": 7,
-        "standardPrice": 1.5,
+        "standardPrice": 2.7,
         "weight": 791
     },
     {
@@ -6591,7 +6591,7 @@
         "price": 49.4,
         "reward": "Jewel",
         "stack": 4,
-        "standardPrice": 5.0,
+        "standardPrice": 4.7,
         "weight": 64
     },
     {
@@ -6670,7 +6670,7 @@
         "price": 4.0,
         "reward": "Flaring Eclipse Staff, Item Level: 100",
         "stack": 7,
-        "standardPrice": 0.7,
+        "standardPrice": 0.96,
         "weight": 1345
     },
     {
@@ -6686,7 +6686,7 @@
         "price": 71.0,
         "reward": "The Saviour, Two-Implicit, Corrupted",
         "stack": 10,
-        "standardPrice": 75.5,
+        "standardPrice": 70.13,
         "weight": 8
     },
     {
@@ -6725,7 +6725,7 @@
         "price": 10.0,
         "reward": "Item, Item Level: 100, Elder Item",
         "stack": 4,
-        "standardPrice": 13.0,
+        "standardPrice": 10.0,
         "weight": 25
     },
     {
@@ -6771,7 +6771,7 @@
         "price": 1.0,
         "reward": "Lifesprig",
         "stack": 9,
-        "standardPrice": 0.71,
+        "standardPrice": 0.92,
         "weight": 18141
     },
     {
@@ -6784,10 +6784,10 @@
         },
         "name": "The Heroic Shot",
         "ninja": "https://poe.ninja/challenge/divination-cards/the-heroic-shot",
-        "price": 3.0,
+        "price": 2.55,
         "reward": "17x Chromatic Orb",
         "stack": 1,
-        "standardPrice": 1.0,
+        "standardPrice": 4.08,
         "weight": 2018
     },
     {
@@ -6807,7 +6807,7 @@
         "price": 29.0,
         "reward": "Machina Mitts, Two-Implicit, Corrupted",
         "stack": 6,
-        "standardPrice": 176.0,
+        "standardPrice": 33.0,
         "weight": 19
     },
     {
@@ -6826,10 +6826,10 @@
         },
         "name": "The Hoarder",
         "ninja": "https://poe.ninja/challenge/divination-cards/the-hoarder",
-        "price": 5.0,
+        "price": 0.9583333333333333,
         "reward": "Exalted Orb",
         "stack": 12,
-        "standardPrice": 1.0,
+        "standardPrice": 2.9375,
         "weight": 2740
     },
     {
@@ -6846,7 +6846,7 @@
         "ninja": "https://poe.ninja/challenge/divination-cards/the-hook",
         "reward": "Level 21 Transfigured Gem, Quality: +23%, Corrupted",
         "stack": 8,
-        "standardPrice": 10.0,
+        "standardPrice": 24.0,
         "weight": 50
     },
     {
@@ -6890,7 +6890,7 @@
         "price": 3834.2,
         "reward": "House of Mirrors",
         "stack": 10,
-        "standardPrice": 3605.29,
+        "standardPrice": 3437.59,
         "weight": 15
     },
     {
@@ -6930,10 +6930,10 @@
         },
         "name": "The Innocent",
         "ninja": "https://poe.ninja/challenge/divination-cards/the-innocent",
-        "price": 3.0,
+        "price": 1.88,
         "reward": "40x Orb of Regret",
         "stack": 10,
-        "standardPrice": 1.0,
+        "standardPrice": 3.24,
         "weight": 1134
     },
     {
@@ -6976,7 +6976,7 @@
         "price": 1361.14,
         "reward": "Mageblood, Item Level: 84, Corrupted",
         "stack": 9,
-        "standardPrice": 2218.64,
+        "standardPrice": 2115.44,
         "weight": 2
     },
     {
@@ -6996,7 +6996,7 @@
         "price": 4.0,
         "reward": "The Harvest, Corrupted",
         "stack": 3,
-        "standardPrice": 0.94,
+        "standardPrice": 1.0,
         "weight": 1218
     },
     {
@@ -7018,10 +7018,10 @@
         },
         "name": "The Inventor",
         "ninja": "https://poe.ninja/challenge/divination-cards/the-inventor",
-        "price": 2.0,
+        "price": 1.5833333333333333,
         "reward": "10x Vaal Orb",
         "stack": 6,
-        "standardPrice": 1.0,
+        "standardPrice": 2.033333333333333,
         "weight": 6775
     },
     {
@@ -7039,7 +7039,7 @@
         "price": 3.0,
         "reward": "Merciless One-Hand Weapon, Item Level: 100",
         "stack": 9,
-        "standardPrice": 2.6,
+        "standardPrice": 3.3,
         "weight": 430
     },
     {
@@ -7084,7 +7084,7 @@
         "price": 2.0,
         "reward": "Helmet, Double-Veiled Item",
         "stack": 10,
-        "standardPrice": 0.49,
+        "standardPrice": 1.0,
         "weight": 12155
     },
     {
@@ -7120,7 +7120,7 @@
         "price": 3.0,
         "reward": "Harbinger's Orb",
         "stack": 3,
-        "standardPrice": 1.6,
+        "standardPrice": 2.0,
         "weight": 753
     },
     {
@@ -7141,7 +7141,7 @@
         "price": 1.0,
         "reward": "Bloodthirsty Eternal Sword, Item Level: 66",
         "stack": 5,
-        "standardPrice": 0.8,
+        "standardPrice": 1.0,
         "weight": 45369
     },
     {
@@ -7202,7 +7202,7 @@
         "price": 60.0,
         "reward": "Atziri's Disfavour",
         "stack": 10,
-        "standardPrice": 33.0,
+        "standardPrice": 8.6,
         "weight": 15
     },
     {
@@ -7220,7 +7220,7 @@
         "price": 32.0,
         "reward": "Bino's Kitchen Knife",
         "stack": 6,
-        "standardPrice": 9.0,
+        "standardPrice": 3.67,
         "weight": 8
     },
     {
@@ -7281,7 +7281,7 @@
         "price": 5.0,
         "reward": "Zerphi's Heart",
         "stack": 6,
-        "standardPrice": 11.6,
+        "standardPrice": 11.8,
         "weight": 63
     },
     {
@@ -7300,7 +7300,7 @@
         "price": 1.0,
         "reward": "Lioneye Item",
         "stack": 5,
-        "standardPrice": 1.0,
+        "standardPrice": 1.6,
         "weight": 3859
     },
     {
@@ -7316,7 +7316,7 @@
         "price": 30.0,
         "reward": "Elderslayer's Exalted Orb",
         "stack": 4,
-        "standardPrice": 24.87,
+        "standardPrice": 35.62,
         "weight": 48
     },
     {
@@ -7386,7 +7386,7 @@
         "price": 0.91,
         "reward": "Jewellery, Item Level: 79",
         "stack": 2,
-        "standardPrice": 0.5,
+        "standardPrice": 0.65,
         "weight": 67504
     },
     {
@@ -7409,7 +7409,7 @@
         "price": 1.0,
         "reward": "Sire of Shards",
         "stack": 5,
-        "standardPrice": 0.8,
+        "standardPrice": 1.0,
         "weight": 7780
     },
     {
@@ -7448,7 +7448,7 @@
         "price": 8.8,
         "reward": "Level 21 Vaal Molten Shell, Corrupted",
         "stack": 6,
-        "standardPrice": 3.2,
+        "standardPrice": 3.0,
         "weight": 391
     },
     {
@@ -7468,7 +7468,7 @@
         "price": 3.0,
         "reward": "Bisco's Collar",
         "stack": 4,
-        "standardPrice": 1.7,
+        "standardPrice": 2.0,
         "weight": 1114
     },
     {
@@ -7503,7 +7503,7 @@
         "price": 3.0,
         "reward": "Shield, Corrupted",
         "stack": 5,
-        "standardPrice": 1.2,
+        "standardPrice": 1.0,
         "weight": 1516
     },
     {
@@ -7542,7 +7542,7 @@
         "price": 0.85,
         "reward": "Prismatic Ring",
         "stack": 6,
-        "standardPrice": 0.34,
+        "standardPrice": 0.35,
         "weight": 36117
     },
     {
@@ -7569,7 +7569,7 @@
         "price": 2.0,
         "reward": "Astral Projector",
         "stack": 7,
-        "standardPrice": 4.3,
+        "standardPrice": 2.6,
         "weight": 126
     },
     {
@@ -7616,7 +7616,7 @@
         "price": 50.0,
         "reward": "The Doctor",
         "stack": 8,
-        "standardPrice": 72.0,
+        "standardPrice": 63.0,
         "weight": 152
     },
     {
@@ -7669,7 +7669,7 @@
         "price": 5.6,
         "reward": "Breachstone",
         "stack": 7,
-        "standardPrice": 2.0,
+        "standardPrice": 1.3,
         "weight": 214
     },
     {
@@ -7712,7 +7712,7 @@
         "price": 6.5,
         "reward": "Ryslatha's Coil",
         "stack": 9,
-        "standardPrice": 7.3,
+        "standardPrice": 8.4,
         "weight": 225
     },
     {
@@ -7737,7 +7737,7 @@
         "price": 52.5,
         "reward": "Fishing Rod, Two-Implicit, Corrupted",
         "stack": 12,
-        "standardPrice": 40.01,
+        "standardPrice": 60.01,
         "weight": 2
     },
     {
@@ -7755,7 +7755,7 @@
         "price": 112.0,
         "reward": "Replica Bated Breath",
         "stack": 7,
-        "standardPrice": 108.3,
+        "standardPrice": 124.8,
         "weight": 1
     },
     {
@@ -7810,7 +7810,7 @@
         "price": 1.0,
         "reward": "Ring, Item Level: 100",
         "stack": 5,
-        "standardPrice": 0.95,
+        "standardPrice": 1.0,
         "weight": 12858
     },
     {
@@ -7882,7 +7882,7 @@
         "price": 7.0,
         "reward": "The Nurse",
         "stack": 8,
-        "standardPrice": 5.8,
+        "standardPrice": 7.0,
         "weight": 712
     },
     {
@@ -7947,7 +7947,7 @@
         "price": 6.0,
         "reward": "Astramentis",
         "stack": 3,
-        "standardPrice": 4.8,
+        "standardPrice": 4.6,
         "weight": 162
     },
     {
@@ -7970,7 +7970,7 @@
         "price": 5.0,
         "reward": "Six-Link Short Bow, Item Level: 50",
         "stack": 6,
-        "standardPrice": 1.0,
+        "standardPrice": 1.4,
         "weight": 3888
     },
     {
@@ -7988,7 +7988,7 @@
         "price": 6633.17,
         "reward": "Mageblood, Quality: +20%, Two-Implicit, Corrupted",
         "stack": 7,
-        "standardPrice": 9706.55,
+        "standardPrice": 10074.78,
         "weight": 4
     },
     {
@@ -8006,7 +8006,7 @@
         "price": 96.0,
         "reward": "Skin of the Loyal, Item Level: 25, Two-Implicit, Corrupted",
         "stack": 4,
-        "standardPrice": 112.5,
+        "standardPrice": 114.0,
         "weight": 7
     },
     {
@@ -8027,7 +8027,7 @@
         "price": 20.0,
         "reward": "Vaal Temple Map, Map Tier: 16, Delirium: 100%, Corrupted",
         "stack": 5,
-        "standardPrice": 3.0,
+        "standardPrice": 6.0,
         "weight": 179
     },
     {
@@ -8140,7 +8140,7 @@
         "price": 28.44,
         "reward": "Jewel, Primordial",
         "stack": 5,
-        "standardPrice": 1.0,
+        "standardPrice": 1.4,
         "weight": 894
     },
     {
@@ -8159,7 +8159,7 @@
         "price": 19.8,
         "reward": "Elegant Hubris",
         "stack": 6,
-        "standardPrice": 6.6,
+        "standardPrice": 6.1,
         "weight": 207
     },
     {
@@ -8180,7 +8180,7 @@
         "price": 5.8,
         "reward": "The Putrid Cloister",
         "stack": 4,
-        "standardPrice": 3.8,
+        "standardPrice": 5.8,
         "weight": 142
     },
     {
@@ -8200,7 +8200,7 @@
         "price": 14.3,
         "reward": "Dying Sun",
         "stack": 2,
-        "standardPrice": 30.0,
+        "standardPrice": 28.6,
         "weight": 19
     },
     {
@@ -8254,7 +8254,7 @@
         "price": 5.0,
         "reward": "Atziri's Acuity",
         "stack": 16,
-        "standardPrice": 14.4,
+        "standardPrice": 14.7,
         "weight": 132
     },
     {
@@ -8274,7 +8274,7 @@
         "price": 9.7,
         "reward": "10x Incursion Vial",
         "stack": 8,
-        "standardPrice": 17.5,
+        "standardPrice": 22.5,
         "weight": 43
     },
     {
@@ -8296,7 +8296,7 @@
         "price": 1.0,
         "reward": "Malicious Gemini Claw, Item Level: 83",
         "stack": 4,
-        "standardPrice": 0.58,
+        "standardPrice": 0.87,
         "weight": 5223
     },
     {
@@ -8365,7 +8365,7 @@
         "price": 5.0,
         "reward": "Tavukai",
         "stack": 3,
-        "standardPrice": 8.0,
+        "standardPrice": 8.4,
         "weight": 946
     },
     {
@@ -8381,7 +8381,7 @@
         "price": 3.0,
         "reward": "Ventor's Gamble",
         "stack": 3,
-        "standardPrice": 5.0,
+        "standardPrice": 3.5,
         "weight": 4827
     },
     {
@@ -8440,10 +8440,10 @@
         },
         "name": "The Rusted Bard",
         "ninja": "https://poe.ninja/challenge/divination-cards/the-rusted-bard",
-        "price": 17.0,
+        "price": 3.4355555555555557,
         "reward": "4x Tainted Mythic Orb",
         "stack": 9,
-        "standardPrice": 20.0,
+        "standardPrice": 8.88888888888889,
         "weight": 140
     },
     {
@@ -8466,7 +8466,7 @@
         "price": 1.0,
         "reward": "Meginord's Girdle, Corrupted",
         "stack": 7,
-        "standardPrice": 0.95,
+        "standardPrice": 1.0,
         "weight": 2703
     },
     {
@@ -8484,7 +8484,7 @@
         "price": 19.8,
         "reward": "Six-Link Sacrificial Garb, Item Level: 100",
         "stack": 4,
-        "standardPrice": 2.6,
+        "standardPrice": 3.0,
         "weight": 34
     },
     {
@@ -8504,10 +8504,10 @@
         },
         "name": "The Saint's Treasure",
         "ninja": "https://poe.ninja/challenge/divination-cards/the-saints-treasure",
-        "price": 5.0,
+        "price": 2.3000000000000003,
         "reward": "2x Exalted Orb",
         "stack": 10,
-        "standardPrice": 1.0,
+        "standardPrice": 7.050000000000001,
         "weight": 1158
     },
     {
@@ -8526,7 +8526,7 @@
         "price": 145.0,
         "reward": "Watcher's Eye",
         "stack": 3,
-        "standardPrice": 71.2,
+        "standardPrice": 73.2,
         "weight": 58
     },
     {
@@ -8549,7 +8549,7 @@
         "price": 1.0,
         "reward": "Wake of Destruction",
         "stack": 9,
-        "standardPrice": 0.4,
+        "standardPrice": 0.33,
         "weight": 18570
     },
     {
@@ -8589,7 +8589,7 @@
         },
         "name": "The Scholar",
         "ninja": "https://poe.ninja/challenge/divination-cards/the-scholar",
-        "price": 1.0,
+        "price": 0.13333333333333333,
         "reward": "40x Scroll of Wisdom",
         "stack": 3,
         "standardPrice": 1.0,
@@ -8617,10 +8617,10 @@
         },
         "name": "The Scout",
         "ninja": "https://poe.ninja/challenge/divination-cards/the-scout-divcard",
-        "price": 10.0,
+        "price": 10.0625,
         "reward": "7x Exalted Orb",
         "stack": 8,
-        "standardPrice": 9.4,
+        "standardPrice": 30.84375,
         "weight": 235
     },
     {
@@ -8635,10 +8635,10 @@
         },
         "name": "The Seeker",
         "ninja": "https://poe.ninja/challenge/divination-cards/the-seeker",
-        "price": 8.0,
+        "price": 4.359999999999999,
         "reward": "3x Orb of Annulment",
         "stack": 9,
-        "standardPrice": 8.6,
+        "standardPrice": 5.826666666666666,
         "weight": 295
     },
     {
@@ -8660,7 +8660,7 @@
         "price": 120.0,
         "reward": "10x Divine Orb",
         "stack": 11,
-        "standardPrice": 120.3,
+        "standardPrice": 112.5,
         "weight": 311
     },
     {
@@ -8681,7 +8681,7 @@
         "price": 30.0,
         "reward": "Boots, Item Level: 100, Two-Implicit, Corrupted",
         "stack": 3,
-        "standardPrice": 15.0,
+        "standardPrice": 12.8,
         "weight": 205
     },
     {
@@ -8699,7 +8699,7 @@
         "price": 76.0,
         "reward": "The Squire",
         "stack": 8,
-        "standardPrice": 831.99,
+        "standardPrice": 475.97,
         "weight": 13
     },
     {
@@ -8775,7 +8775,7 @@
         "price": 15.0,
         "reward": "Quicksilver Flask of the Cheetah, Item Level: 100",
         "stack": 1,
-        "standardPrice": 15.2,
+        "standardPrice": 8.0,
         "weight": 121
     },
     {
@@ -8802,7 +8802,7 @@
         "price": 4.0,
         "reward": "20x Scouting Report",
         "stack": 5,
-        "standardPrice": 1.4,
+        "standardPrice": 1.6,
         "weight": 712
     },
     {
@@ -8885,7 +8885,7 @@
         "price": 22.0,
         "reward": "Soul Taker",
         "stack": 9,
-        "standardPrice": 2.8,
+        "standardPrice": 10.0,
         "weight": 11
     },
     {
@@ -8989,7 +8989,7 @@
         "price": 8.8,
         "reward": "Inspired Learning, Corrupted",
         "stack": 6,
-        "standardPrice": 7.6,
+        "standardPrice": 7.8,
         "weight": 33
     },
     {
@@ -9078,7 +9078,7 @@
         "price": 1.0,
         "reward": "Map, Map Tier: 14",
         "stack": 4,
-        "standardPrice": 0.95,
+        "standardPrice": 1.0,
         "weight": 4561
     },
     {
@@ -9096,10 +9096,10 @@
         },
         "name": "The Survivalist",
         "ninja": "https://poe.ninja/challenge/divination-cards/the-survivalist",
-        "price": 1.0,
+        "price": 0.16333333333333336,
         "reward": "7x Orb of Alchemy",
         "stack": 3,
-        "standardPrice": 1.0,
+        "standardPrice": 0.04666666666666667,
         "weight": 7683
     },
     {
@@ -9122,7 +9122,7 @@
         "price": 1.0,
         "reward": "Daresso's Salute",
         "stack": 7,
-        "standardPrice": 0.62,
+        "standardPrice": 0.8,
         "weight": 14514
     },
     {
@@ -9143,7 +9143,7 @@
         "price": 5.9,
         "reward": "Shavronne's Revelation, Corrupted",
         "stack": 8,
-        "standardPrice": 1.9,
+        "standardPrice": 3.0,
         "weight": 119
     },
     {
@@ -9163,7 +9163,7 @@
         "price": 4.9,
         "reward": "Kaom's Roots, Corrupted",
         "stack": 2,
-        "standardPrice": 6.0,
+        "standardPrice": 5.2,
         "weight": 148
     },
     {
@@ -9330,7 +9330,7 @@
         "price": 1.0,
         "reward": "5x Fossil",
         "stack": 5,
-        "standardPrice": 0.9,
+        "standardPrice": 1.0,
         "weight": 239
     },
     {
@@ -9416,10 +9416,10 @@
         },
         "name": "The Transformation",
         "ninja": "https://poe.ninja/challenge/divination-cards/the-transformation",
-        "price": 4.5,
+        "price": 1.5460000000000003,
         "reward": "Tainted Mythic Orb",
         "stack": 5,
-        "standardPrice": 1.7,
+        "standardPrice": 4.0,
         "weight": 301
     },
     {
@@ -9608,7 +9608,7 @@
         "price": 8.6,
         "reward": "Diamond Ring of Redemption, Item Level: 100, Redeemer Item",
         "stack": 2,
-        "standardPrice": 8.2,
+        "standardPrice": 9.1,
         "weight": 28
     },
     {
@@ -9674,7 +9674,7 @@
         "price": 4.0,
         "reward": "Merciless Weapon, Item Level: 100",
         "stack": 9,
-        "standardPrice": 1.4,
+        "standardPrice": 3.0,
         "weight": 405
     },
     {
@@ -9712,7 +9712,7 @@
         "price": 8.0,
         "reward": "Merciless Vaal Axe, Item Level: 100, Elder Item",
         "stack": 8,
-        "standardPrice": 5.6,
+        "standardPrice": 5.0,
         "weight": 18
     },
     {
@@ -9732,7 +9732,7 @@
         "price": 9.9,
         "reward": "Attribute Transforming Jewel, Corrupted",
         "stack": 2,
-        "standardPrice": 3.5,
+        "standardPrice": 3.0,
         "weight": 301
     },
     {
@@ -9802,7 +9802,7 @@
         "price": 20.0,
         "reward": "Song of the Sirens",
         "stack": 7,
-        "standardPrice": 20.0,
+        "standardPrice": 18.5,
         "weight": 12
     },
     {
@@ -9844,7 +9844,7 @@
         "price": 4.0,
         "reward": "",
         "stack": 1,
-        "standardPrice": 4.4,
+        "standardPrice": 5.0,
         "weight": 10062
     },
     {
@@ -9890,7 +9890,7 @@
         "price": 9.0,
         "reward": "Six-Link Coronal Maul, Item Level: 83",
         "stack": 6,
-        "standardPrice": 2.0,
+        "standardPrice": 2.9,
         "weight": 619
     },
     {
@@ -9951,7 +9951,7 @@
         "price": 10.0,
         "reward": "Arakaali's Fang",
         "stack": 2,
-        "standardPrice": 10.8,
+        "standardPrice": 7.0,
         "weight": 50
     },
     {
@@ -9969,7 +9969,7 @@
         "price": 19.4,
         "reward": "Six-Link Astral Plate, Item Level: 100, Crusader Item",
         "stack": 8,
-        "standardPrice": 3.4,
+        "standardPrice": 6.0,
         "weight": 35
     },
     {
@@ -9987,7 +9987,7 @@
         "price": 5.0,
         "reward": "Cospri's Malice",
         "stack": 8,
-        "standardPrice": 1.6,
+        "standardPrice": 3.0,
         "weight": 427
     },
     {
@@ -10028,7 +10028,7 @@
         "price": 3.0,
         "reward": "Windripper",
         "stack": 7,
-        "standardPrice": 2.4,
+        "standardPrice": 2.0,
         "weight": 311
     },
     {
@@ -10131,7 +10131,7 @@
         "price": 4.0,
         "reward": "Rigwald's Quills",
         "stack": 8,
-        "standardPrice": 5.4,
+        "standardPrice": 5.0,
         "weight": 442
     },
     {
@@ -10170,7 +10170,7 @@
         "price": 50.0,
         "reward": "Starforge",
         "stack": 8,
-        "standardPrice": 16.0,
+        "standardPrice": 10.0,
         "weight": 10
     },
     {
@@ -10365,7 +10365,7 @@
         "price": 14.0,
         "reward": "Voltaxic Rift",
         "stack": 7,
-        "standardPrice": 5.1,
+        "standardPrice": 5.5,
         "weight": 9
     },
     {
@@ -10429,7 +10429,7 @@
         "price": 15.0,
         "reward": "Pacifism, Corrupted",
         "stack": 3,
-        "standardPrice": 1.0,
+        "standardPrice": 0.97,
         "weight": 510
     },
     {
@@ -10472,7 +10472,7 @@
         "price": 17253.9,
         "reward": "19x Mirror Shard",
         "stack": 16,
-        "standardPrice": 15031.29,
+        "standardPrice": 15707.14,
         "weight": 2
     },
     {
@@ -10534,10 +10534,10 @@
         },
         "name": "Vinia's Token",
         "ninja": "https://poe.ninja/challenge/divination-cards/vinias-token",
-        "price": 1.0,
+        "price": 0.94,
         "reward": "10x Orb of Regret",
         "stack": 5,
-        "standardPrice": 1.0,
+        "standardPrice": 1.62,
         "weight": 12137
     },
     {
@@ -10603,7 +10603,7 @@
         "price": 383.42,
         "reward": "Level 4 Enlighten, Corrupted",
         "stack": 11,
-        "standardPrice": 83.0,
+        "standardPrice": 72.0,
         "weight": 29
     },
     {
@@ -10622,7 +10622,7 @@
         "price": 40.0,
         "reward": "Dictator's Weapon, Item Level: 83, Fractured",
         "stack": 9,
-        "standardPrice": 146.0
+        "standardPrice": 188.0
     },
     {
         "art": "WintersEmbrace",
@@ -10637,7 +10637,7 @@
         "price": 50.0,
         "reward": "Circle of Fear, Three-Implicit, Synthesised",
         "stack": 2,
-        "standardPrice": 54.54,
+        "standardPrice": 64.1,
         "weight": 38
     }
 ]

--- a/site/src/state.js
+++ b/site/src/state.js
@@ -518,6 +518,10 @@ function createState() {
     atlasLabels: atomWithStore('atlasLabels', true, data)
   }
 
+  const alerts = {
+    cardPrices: atomWithStore('cardPricesAlert', true)
+  }
+
   const parsedSearch = atom(
     get => parseSearch(get(input.search)),
     (get, set, e) => {
@@ -585,6 +589,7 @@ function createState() {
     monsters,
     globals,
     input,
+    alerts,
     parsedSearch,
     mapRegex,
     ratedMaps,


### PR DESCRIPTION
Instead of using ninja prices for currency cards, use ninja prices for currencies directly, divide by stack size, multiply by reward size. This makes sure that the real value for the cards is not skewed with inaccurate trade data for cards.